### PR TITLE
Introduce overriders provider

### DIFF
--- a/src/OverridesProvider.php
+++ b/src/OverridesProvider.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ReactParallel\Psr11ContainerProxy;
+
+use ReactParallel\ObjectProxy\ProxyListInterface;
+
+final class OverridesProvider
+{
+    private ProxyListInterface $proxyList;
+
+    public function __construct(ProxyListInterface $proxyList)
+    {
+        $this->proxyList = $proxyList;
+    }
+
+    /**
+     * @return iterable<string>
+     */
+    public function list(): iterable
+    {
+        $list = [];
+
+        foreach ($this->proxyList->interfaces() as $interface) {
+            $list[$interface] = $interface;
+        }
+
+        foreach ($this->proxyList->noPromiseKnownInterfaces() as $noPromiseInterface => $interface) {
+            $list[$noPromiseInterface] = $interface;
+        }
+
+        yield from $list;
+    }
+}

--- a/tests/OverridesProviderTest.php
+++ b/tests/OverridesProviderTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ReactParallel\Tests\Psr11ContainerProxy;
+
+use ReactParallel\ObjectProxy\ProxyList\Proxy;
+use ReactParallel\ObjectProxy\ProxyListInterface;
+use ReactParallel\Psr11ContainerProxy\OverridesProvider;
+use WyriHaximus\AsyncTestUtilities\AsyncTestCase;
+
+use function WyriHaximus\iteratorOrArrayToArray;
+
+final class OverridesProviderTest extends AsyncTestCase
+{
+    /**
+     * @test
+     */
+    public function list(): void
+    {
+        $proxyList = new class () implements ProxyListInterface {
+            public function has(string $interface): bool
+            {
+                return false;
+            }
+
+            public function get(string $interface): Proxy
+            {
+                return new Proxy($interface, $interface);
+            }
+
+            /**
+             * @return iterable<string, string>
+             */
+            public function interfaces(): iterable
+            {
+                yield 'pizza' => 'fungi';
+                yield 'pancake' => 'pancake';
+            }
+
+            /**
+             * @return array<string, string>
+             */
+            public function noPromiseKnownInterfaces(): array
+            {
+                return ['pancake' => 'cheese union'];
+            }
+        };
+
+        $list = iteratorOrArrayToArray((new OverridesProvider($proxyList))->list());
+
+        self::assertSame([
+            'fungi' => 'fungi',
+            'pancake' => 'cheese union',
+        ], $list);
+    }
+}


### PR DESCRIPTION
This provider is useful for other packages using this container proxy to have their one stop iterator for definitions they need to proxy.